### PR TITLE
Add table and controller for penalty requests

### DIFF
--- a/src/Lounge.Web/Controllers/PenaltyRequestsController.cs
+++ b/src/Lounge.Web/Controllers/PenaltyRequestsController.cs
@@ -1,0 +1,129 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Lounge.Web.Data;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Lounge.Web.Utils;
+using Lounge.Web.Settings;
+using System.Linq;
+using Lounge.Web.Models.ViewModels;
+using Lounge.Web.Data.Entities;
+using Lounge.Web.Models.Enums;
+
+namespace Lounge.Web.Controllers
+{
+    [Route("api/penaltyrequest")]
+    [Authorize]
+    [ApiController]
+    public class PenaltyRequestsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ILoungeSettingsService _loungeSettingsService;
+
+        public PenaltyRequestsController(ApplicationDbContext context, ILoungeSettingsService loungeSettingsService)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _loungeSettingsService = loungeSettingsService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<PenaltyRequestViewModel>> GetPenaltyRequest(int id, Game game = Game.mk8dx)
+        {
+            var requestData = await _context.PenaltyRequests
+                .AsNoTracking()
+                .Where(r => r.Id == id && r.Game == (int)game)
+                .Select(r => new { PenaltyRequest = r, PlayerName = r.Player.Name, ReporterName = r.Reporter == null ? string.Empty : r.Reporter.Name })
+                .FirstOrDefaultAsync();
+
+            if (requestData is null)
+            {
+                return NotFound();
+            }
+
+            return PenaltyRequestUtils.GetPenaltyRequestDetails(requestData.PenaltyRequest, requestData.PlayerName, requestData.ReporterName);
+        }
+
+        [HttpGet("list")]
+        public async Task<ActionResult<List<PenaltyRequestViewModel>>> GetPenaltyRequests(Game game = Game.mk8dx)
+        {
+            var requestsData = await _context.PenaltyRequests
+                .AsNoTracking()
+                .Where(r => r.Game == (int)game)
+                .Select(r => new { PenaltyRequest = r, PlayerName = r.Player.Name, ReporterName = r.Reporter == null ? string.Empty : r.Reporter.Name})
+                .ToArrayAsync();
+
+            if (requestsData is null)
+            {
+                return NotFound();
+            }
+
+            return requestsData.Select(r => PenaltyRequestUtils.GetPenaltyRequestDetails(r.PenaltyRequest, r.PlayerName, r.ReporterName)).ToList();
+        }
+
+        [HttpPost("create")]
+        public async Task<ActionResult<PenaltyRequestViewModel>> SubmitPenaltyRequest(string penaltyType, string playerName, string reporterName, int tableID, int numberOfRaces, Game game = Game.mk8dx)
+        {
+            var player = await _context.PlayerGameRegistrations
+                .Where(pgr => pgr.Game == (int)game)
+                .Select(pgr => pgr.Player)
+                .Where(p => p.NormalizedName == PlayerUtils.NormalizeName(playerName))
+                .Select(p => new { p.Id, p.Name })
+                .SingleOrDefaultAsync();
+
+            if (player is null) 
+            { 
+                return NotFound();
+            }
+
+            var reporter = await _context.PlayerGameRegistrations
+                .Where(pgr => pgr.Game == (int)game)
+                .Select(pgr => pgr.Player)
+                .Where(p => p.NormalizedName == PlayerUtils.NormalizeName(reporterName))
+                .Select(p => new { p.Id, p.Name })
+                .SingleOrDefaultAsync();
+
+            if (reporter is null)
+            {
+                return NotFound();
+            }
+
+            PenaltyRequest request = new()
+            {
+                Game = (int)game,
+                PenaltyName = penaltyType,
+                TableId = tableID,
+                NumberOfRaces = numberOfRaces,
+                PlayerId = player.Id,
+                ReporterId = reporter.Id
+            };
+
+            _context.PenaltyRequests.Add(request);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetPenaltyRequest), new { id = request.Id }, PenaltyRequestUtils.GetPenaltyRequestDetails(request, player.Name, reporter.Name));
+
+        }
+
+        [HttpDelete]
+        public async Task<IActionResult> Delete(int id, Game game = Game.mk8dx)
+        {
+            var requestData = await _context.PenaltyRequests
+                .Where(r => r.Id == id && r.Game == (int)game)
+                .Select(r => new { PenaltyRequest = r })
+                .FirstOrDefaultAsync();
+
+            if (requestData is null)
+            {
+                return NotFound();
+            }
+
+            _context.PenaltyRequests.Remove(requestData.PenaltyRequest);
+            await _context.SaveChangesAsync();
+
+            return Ok();
+
+        }
+    }
+}

--- a/src/Lounge.Web/Data/ApplicationDbContext.cs
+++ b/src/Lounge.Web/Data/ApplicationDbContext.cs
@@ -22,6 +22,7 @@ namespace Lounge.Web.Data
         public DbSet<Table> Tables => Set<Table>();
         public DbSet<TableScore> TableScores => Set<TableScore>();
         public DbSet<Penalty> Penalties => Set<Penalty>();
+        public DbSet<PenaltyRequest> PenaltyRequests => Set<PenaltyRequest>();
         public DbSet<Bonus> Bonuses => Set<Bonus>();
         public DbSet<Placement> Placements => Set<Placement>();
         public DbSet<NameChange> NameChanges => Set<NameChange>();
@@ -36,6 +37,7 @@ namespace Lounge.Web.Data
             modelBuilder.Entity<Table>().ToTable("Tables");
             modelBuilder.Entity<TableScore>().ToTable("TableScores");
             modelBuilder.Entity<Penalty>().ToTable("Penalties");
+            modelBuilder.Entity<PenaltyRequest>().ToTable("PenaltyRequests");
             modelBuilder.Entity<Bonus>().ToTable("Bonuses");
             modelBuilder.Entity<Placement>().ToTable("Placements");
             modelBuilder.Entity<NameChange>().ToTable("NameChanges");

--- a/src/Lounge.Web/Data/Entities/PenaltyRequest.cs
+++ b/src/Lounge.Web/Data/Entities/PenaltyRequest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Lounge.Web.Data.Entities
+{
+    public class PenaltyRequest
+    {
+        public int Id { get; set; }
+        public int Game { get; set; } = (int)Models.Enums.Game.mk8dx;
+        public string PenaltyName { get; set; } = default!;
+        public int TableId { get; set; }
+        public Table Table { get; set; } = default!;
+        public int NumberOfRaces { get; set; }
+
+        public int? ReporterId {  get; set; }
+        public Player? Reporter { get; set; } = default!;
+
+        public int PlayerId { get; set; }
+        public Player Player { get; set; } = default!;
+    }
+}

--- a/src/Lounge.Web/Migrations/20250619213848_AddPenaltyRequests.Designer.cs
+++ b/src/Lounge.Web/Migrations/20250619213848_AddPenaltyRequests.Designer.cs
@@ -4,6 +4,7 @@ using Lounge.Web.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Lounge.Web.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619213848_AddPenaltyRequests")]
+    partial class AddPenaltyRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Lounge.Web/Migrations/20250619213848_AddPenaltyRequests.cs
+++ b/src/Lounge.Web/Migrations/20250619213848_AddPenaltyRequests.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lounge.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPenaltyRequests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PenaltyRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Game = table.Column<int>(type: "int", nullable: false),
+                    PenaltyName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TableId = table.Column<int>(type: "int", nullable: false),
+                    NumberOfRaces = table.Column<int>(type: "int", nullable: false),
+                    ReporterId = table.Column<int>(type: "int", nullable: true),
+                    PlayerId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PenaltyRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PenaltyRequests_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PenaltyRequests_Players_ReporterId",
+                        column: x => x.ReporterId,
+                        principalTable: "Players",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_PenaltyRequests_Tables_TableId",
+                        column: x => x.TableId,
+                        principalTable: "Tables",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PenaltyRequests_PlayerId",
+                table: "PenaltyRequests",
+                column: "PlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PenaltyRequests_ReporterId",
+                table: "PenaltyRequests",
+                column: "ReporterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PenaltyRequests_TableId",
+                table: "PenaltyRequests",
+                column: "TableId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PenaltyRequests");
+        }
+    }
+}

--- a/src/Lounge.Web/Models/ViewModels/PenaltyRequestViewModel.cs
+++ b/src/Lounge.Web/Models/ViewModels/PenaltyRequestViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Lounge.Web.Models.Enums;
+
+namespace Lounge.Web.Models.ViewModels
+{
+    public class PenaltyRequestViewModel
+    {
+        public int Id { get; init; }
+        public Game Game { get; init; }
+        public string PenaltyName { get; init; } = default!;
+        public int TableId { get; init; }
+        public int NumberOfRaces { get; init; }
+        public int PlayerId { get; init; }
+        public required string PlayerName { get; init; }
+        public int ReporterId { get; init; }
+        public required string ReporterName { get; init; }
+    }
+}

--- a/src/Lounge.Web/Utils/PenaltyRequestUtils.cs
+++ b/src/Lounge.Web/Utils/PenaltyRequestUtils.cs
@@ -1,0 +1,25 @@
+﻿using Lounge.Web.Data.Entities;
+using Lounge.Web.Models.Enums;
+using Lounge.Web.Models.ViewModels;
+
+namespace Lounge.Web.Utils
+{
+    public static class PenaltyRequestUtils
+    {
+        public static PenaltyRequestViewModel GetPenaltyRequestDetails(PenaltyRequest request, string playerName, string reporterName)
+        {
+            return new PenaltyRequestViewModel
+            {
+                Id = request.Id,
+                Game = (Game)request.Game,
+                PenaltyName = request.PenaltyName,
+                TableId = request.TableId,
+                NumberOfRaces = request.NumberOfRaces,
+                ReporterId = request.ReporterId ?? default,
+                ReporterName = reporterName,
+                PlayerId = request.PlayerId,
+                PlayerName = playerName
+            };
+        }
+    }
+}


### PR DESCRIPTION
Add a new table to store and retrieve penalty requests issued by players using the updating bot. This should be mostly independent of everything else, hidden from players and it can be safely deleted after validation or refusal without any consequences as every steps is logged in the discord server.

~~It worked well before your last commits on the new Game attribute. Now I encounter a KeyNotFoundException on line 59 in file PlayerStatsCache because it contains no value when trying to add a new player to the db. Not sure if it's me missing something but I already tried to clean my db and re setup everything but it still doesn't work.~~ I rebased and it's all good know.

Don't hesitate to let me know if something is missing or unclear.